### PR TITLE
Update createConditions method

### DIFF
--- a/JotForm.php
+++ b/JotForm.php
@@ -170,7 +170,7 @@ class JotForm {
              if (${$arg}) {
                  $params[strtolower($arg)] = ${$arg};
                  if ($arg == "filter") {
-                     $params[$arg] = urlEncode(json_encode($params[$arg]));
+                     $params[$arg] = urlencode(json_encode($params[$arg]));
                  }
              }
         }


### PR DESCRIPTION
Update `createConditions` method to `urlEncode()` filter variables. I noticed some unanswered forum posts and needed to fix this quickly. Values passed for the 'filter' parameter were being appended as a raw JSON object and returning an empty error.