### PR TITLE
fix: assume euOnly property always exists

### DIFF
--- a/JotForm.php
+++ b/JotForm.php
@@ -23,7 +23,7 @@ class JotForm {
         $this->outputType = strtolower($outputType);
         $user = $this->getUser();
         # set base url for EU users
-        if (isset($user['euOnly'])) {
+        if (isset($user['euOnly']) && !empty($user['euOnly'])) {
             $this->baseURL = 'https://eu-api.jotform.com';
         }
     }


### PR DESCRIPTION
A recent api change to /user made it so the 'euOnly' property was always set, but set to 0 if it wasn't enabled.